### PR TITLE
SYWA-15: toevoegen editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+# editorconfig-tools is unable to ignore longs strings or urls
+max_line_length = off
+
+[CHANGELOG.md]
+indent_size = false

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ dist
 
 # TernJS port file
 .tern-port
+.idea


### PR DESCRIPTION
# SYWA-15: Toevoegen .editorconfig file:

## Wat is er gedaan:

### 📝 Toevoegen .editorconfig
We maken gebruik van de .editorconfig van airbnb om onze editors dezelfde basic rulesets te laten volgen bij het maken van nieuwe files, plaatsen van spaties en tabs etc...

### ❗❗ OPGELET: Editor aanpassen 
Je dient te kijken of je editor automatisch de `.editorconfig` opneemt en vervolgens enforced bij het zetten van spaties/tabs,... dit is niet altijd het geval.

### ℹ Minor changes:

- Aanpassingen aan de .gitignore omdat deze nog niet op development zit. Toevoegen van de `idea` foler.
